### PR TITLE
Fix reading too large registers

### DIFF
--- a/lilygo-rs485-2.yaml
+++ b/lilygo-rs485-2.yaml
@@ -490,7 +490,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Total Discharging Energy"
@@ -505,7 +504,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Daily Charging Energy"
@@ -520,7 +518,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Daily Discharging Energy"
@@ -535,7 +532,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Monthly Charging Energy"
@@ -550,7 +546,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Monthly Discharging Energy"
@@ -565,7 +560,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Internal Temperature"

--- a/lilygo-rs485-3.yaml
+++ b/lilygo-rs485-3.yaml
@@ -490,7 +490,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Total Discharging Energy"
@@ -505,7 +504,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Daily Charging Energy"
@@ -520,7 +518,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Daily Discharging Energy"
@@ -535,7 +532,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Monthly Charging Energy"
@@ -550,7 +546,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Monthly Discharging Energy"
@@ -565,7 +560,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Internal Temperature"

--- a/lilygo-rs485.yaml
+++ b/lilygo-rs485.yaml
@@ -490,7 +490,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Total Discharging Energy"
@@ -505,7 +504,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Daily Charging Energy"
@@ -520,7 +518,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Daily Discharging Energy"
@@ -535,7 +532,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Monthly Charging Energy"
@@ -550,7 +546,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Monthly Discharging Energy"
@@ -565,7 +560,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
-    register_count: 2
     skip_updates: 60 # 5 minutes
 
   - name: "Marstek Internal Temperature"


### PR DESCRIPTION
For the totals, two U_DWORD registers are read, therefore 8 bytes instead of 4. This causes totals to read the result of the next register and use that result instead.

The number of registers to read is determined by value_type and therefore register_count is not needed.

This code is untested, but based on previous experience.