### PR TITLE
correct Max/Min Cell Temperature by multiplying value by 0.1 for BMS …

### DIFF
--- a/MarstekVenus-Lilygo-T-POE-Pro.yaml
+++ b/MarstekVenus-Lilygo-T-POE-Pro.yaml
@@ -996,7 +996,16 @@ sensor:
     accuracy_decimals: 1
     skip_updates: 60 # 5 minutes
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 22
@@ -1014,7 +1023,16 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 23

--- a/MarstekVenus-Lilygo-T-POE-Pro2.yaml
+++ b/MarstekVenus-Lilygo-T-POE-Pro2.yaml
@@ -996,7 +996,16 @@ sensor:
     accuracy_decimals: 1
     skip_updates: 60 # 5 minutes
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 22
@@ -1014,7 +1023,16 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 23

--- a/MarstekVenus-Lilygo-T-POE-Pro3.yaml
+++ b/MarstekVenus-Lilygo-T-POE-Pro3.yaml
@@ -996,7 +996,16 @@ sensor:
     accuracy_decimals: 1
     skip_updates: 60 # 5 minutes
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 22
@@ -1014,7 +1023,16 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 23

--- a/lilygo-rs485-2.yaml
+++ b/lilygo-rs485-2.yaml
@@ -1024,7 +1024,16 @@ sensor:
     accuracy_decimals: 1
     skip_updates: 60 # 5 minutes
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 22
@@ -1042,7 +1051,16 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 23

--- a/lilygo-rs485-3.yaml
+++ b/lilygo-rs485-3.yaml
@@ -1024,7 +1024,16 @@ sensor:
     accuracy_decimals: 1
     skip_updates: 60 # 5 minutes
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 22
@@ -1042,7 +1051,16 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 23

--- a/lilygo-rs485.yaml
+++ b/lilygo-rs485.yaml
@@ -1024,7 +1024,16 @@ sensor:
     accuracy_decimals: 1
     skip_updates: 60 # 5 minutes
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 22
@@ -1042,7 +1051,16 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     filters:
-      - multiply: 1
+      - lambda: |-
+          // Extract the numeric part of the BMS version (e.g., "V213" -> 213)
+          std::string version_str = id(bms_version_text).state;
+          unsigned int version_num = 0;
+          if (version_str.length() > 1 && version_str[0] == 'V') {
+            version_num = std::stoul(version_str.substr(1));
+          }
+          // Multiply by 0.1 for BMS version < 2.13
+          float multiplier = (version_num < 213) ? 0.1f : 1.0f;
+          return x * multiplier;
     web_server:
       sorting_group_id: Info
       sorting_weight: 23


### PR DESCRIPTION
For BMS versions < 2.13, Min and Max Cel Temperature values should be multiplied by 0.1. Otherwise you will get 210 degrees instead of 21 degrees. Based on the BMS version of the battery, it is possible to automatically correct the values by checking the BMS version in lambda code in this branch. This has been tested on my two batteries that were running V2.12 and V2.13 BMS versions. Temperature values were correctly reported by ESPHome, also after upgrading BMS on the V2.12 battery to V2.16.