### PR TITLE
add switch to disable the status script

### DIFF
--- a/lilygo-rs485.yaml
+++ b/lilygo-rs485.yaml
@@ -1393,50 +1393,64 @@ light:
     name: "Status LED"
     id: status_led
 
+# switch to enable/disable the LED interval logic
+switch:
+  - platform: template
+    icon: mdi:lightbulb-alert
+    name: "LED Device status"
+    id: led_device_status
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON  # Start enabled after reboot
+
 interval:
   - interval: 5s
-    then:
-      - lambda: |-
-          ESP_LOGD("status", "Modbus: %.0f, WiFi: %.0f", id(modbus_status).state, id(wifi_strength).state);
       - if:
           condition:
             lambda: |-
-              return !isnan(id(modbus_status).state) && id(wifi_strength).state > -80;
-          then:
-            - light.turn_on:
-                id: status_led
-                red: 0%
-                green: 100%  # 🟢 Green = Modbus OK & WiFi strong
-                blue: 0%
-                brightness: !lambda "return id(led_brightness).state / 100.0;"
-          else:
-            - if:
-                condition:
-                  lambda: |-
-                    return isnan(id(modbus_status).state) && id(wifi_strength).state < -80;
-                then:
-                  - light.turn_on:
-                      id: status_led
-                      red: 100%  # 🟣 Purple = Both Modbus & WiFi failed
-                      green: 0%
-                      blue: 100%
-                      brightness: !lambda "return id(led_brightness).state / 100.0;"
-                else:
-                  - if:
-                      condition:
-                        lambda: |-
-                          return id(wifi_strength).state < -80;
-                      then:
-                        - light.turn_on:
-                            id: status_led
-                            red: 0%
-                            green: 0%
-                            blue: 100%  # 🔵 Blue = Weak WiFi signal (< -80 dBm)
-                            brightness: !lambda "return id(led_brightness).state / 100.0;"
-                      else:
-                        - light.turn_on:
-                            id: status_led
-                            red: 100%  # 🔴 Red = Modbus error, WiFi OK
-                            green: 0%
-                            blue: 0%
-                            brightness: !lambda "return id(led_brightness).state / 100.0;"
+              // Only run the LED logic if the switch is ON
+              return id(led_device_status).state;  
+      then:
+        - lambda: |-
+            ESP_LOGD("status", "Modbus: %.0f, WiFi: %.0f", id(modbus_status).state, id(wifi_strength).state);
+        - if:
+            condition:
+              lambda: |-
+                return !isnan(id(modbus_status).state) && id(wifi_strength).state > -80;
+            then:
+              - light.turn_on:
+                  id: status_led
+                  red: 0%
+                  green: 100%  # 🟢 Green = Modbus OK & WiFi strong
+                  blue: 0%
+                  brightness: !lambda "return id(led_brightness).state / 100.0;"
+            else:
+              - if:
+                  condition:
+                    lambda: |-
+                      return isnan(id(modbus_status).state) && id(wifi_strength).state < -80;
+                  then:
+                    - light.turn_on:
+                        id: status_led
+                        red: 100%  # 🟣 Purple = Both Modbus & WiFi failed
+                        green: 0%
+                        blue: 100%
+                        brightness: !lambda "return id(led_brightness).state / 100.0;"
+                  else:
+                    - if:
+                        condition:
+                          lambda: |-
+                            return id(wifi_strength).state < -80;
+                        then:
+                          - light.turn_on:
+                              id: status_led
+                              red: 0%
+                              green: 0%
+                              blue: 100%  # 🔵 Blue = Weak WiFi signal (< -80 dBm)
+                              brightness: !lambda "return id(led_brightness).state / 100.0;"
+                        else:
+                          - light.turn_on:
+                              id: status_led
+                              red: 100%  # 🔴 Red = Modbus error, WiFi OK
+                              green: 0%
+                              blue: 0%
+                              brightness: !lambda "return id(led_brightness).state / 100.0;"

--- a/lilygo-rs485.yaml
+++ b/lilygo-rs485.yaml
@@ -1404,53 +1404,54 @@ switch:
 
 interval:
   - interval: 5s
+    then:
       - if:
           condition:
             lambda: |-
               // Only run the LED logic if the switch is ON
               return id(led_device_status).state;  
-      then:
-        - lambda: |-
-            ESP_LOGD("status", "Modbus: %.0f, WiFi: %.0f", id(modbus_status).state, id(wifi_strength).state);
-        - if:
-            condition:
-              lambda: |-
-                return !isnan(id(modbus_status).state) && id(wifi_strength).state > -80;
-            then:
-              - light.turn_on:
-                  id: status_led
-                  red: 0%
-                  green: 100%  # 🟢 Green = Modbus OK & WiFi strong
-                  blue: 0%
-                  brightness: !lambda "return id(led_brightness).state / 100.0;"
-            else:
-              - if:
-                  condition:
-                    lambda: |-
-                      return isnan(id(modbus_status).state) && id(wifi_strength).state < -80;
-                  then:
-                    - light.turn_on:
-                        id: status_led
-                        red: 100%  # 🟣 Purple = Both Modbus & WiFi failed
-                        green: 0%
-                        blue: 100%
-                        brightness: !lambda "return id(led_brightness).state / 100.0;"
-                  else:
-                    - if:
-                        condition:
-                          lambda: |-
-                            return id(wifi_strength).state < -80;
-                        then:
-                          - light.turn_on:
-                              id: status_led
-                              red: 0%
-                              green: 0%
-                              blue: 100%  # 🔵 Blue = Weak WiFi signal (< -80 dBm)
-                              brightness: !lambda "return id(led_brightness).state / 100.0;"
-                        else:
-                          - light.turn_on:
-                              id: status_led
-                              red: 100%  # 🔴 Red = Modbus error, WiFi OK
-                              green: 0%
-                              blue: 0%
-                              brightness: !lambda "return id(led_brightness).state / 100.0;"
+          then:
+            - lambda: |-
+                ESP_LOGD("status", "Modbus: %.0f, WiFi: %.0f", id(modbus_status).state, id(wifi_strength).state);
+            - if:
+                condition:
+                  lambda: |-
+                    return !isnan(id(modbus_status).state) && id(wifi_strength).state > -80;
+                then:
+                  - light.turn_on:
+                      id: status_led
+                      red: 0%
+                      green: 100%  # 🟢 Green = Modbus OK & WiFi strong
+                      blue: 0%
+                      brightness: !lambda "return id(led_brightness).state / 100.0;"
+                else:
+                  - if:
+                      condition:
+                        lambda: |-
+                          return isnan(id(modbus_status).state) && id(wifi_strength).state < -80;
+                      then:
+                        - light.turn_on:
+                            id: status_led
+                            red: 100%  # 🟣 Purple = Both Modbus & WiFi failed
+                            green: 0%
+                            blue: 100%
+                            brightness: !lambda "return id(led_brightness).state / 100.0;"
+                      else:
+                        - if:
+                            condition:
+                              lambda: |-
+                                return id(wifi_strength).state < -80;
+                            then:
+                              - light.turn_on:
+                                  id: status_led
+                                  red: 0%
+                                  green: 0%
+                                  blue: 100%  # 🔵 Blue = Weak WiFi signal (< -80 dBm)
+                                  brightness: !lambda "return id(led_brightness).state / 100.0;"
+                            else:
+                              - light.turn_on:
+                                  id: status_led
+                                  red: 100%  # 🔴 Red = Modbus error, WiFi OK
+                                  green: 0%
+                                  blue: 0%
+                                  brightness: !lambda "return id(led_brightness).state / 100.0;"


### PR DESCRIPTION
The actual intended change from #23 is not implemented. (though i'm happy that you could fix the brightness setting, which I couldn`t)

This pull adds a switch which disables the status script. This way it enables the user to control the LED with HA with own automations.

Code: the pulls adds a button and an extra if statement. 